### PR TITLE
Harden Rasa runtime auth defaults and CI supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,10 +26,10 @@ jobs:
     outputs:
       langs: ${{ steps.langs.outputs.langs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.x"
       - name: Get language/region matrix
@@ -45,7 +45,7 @@ jobs:
       changed_langs: ${{ steps.filter.outputs.changed_langs }}
       changed_langs_json: ${{ steps.filter.outputs.changed_langs_json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
       - name: Determine base ref
@@ -110,7 +110,9 @@ jobs:
   build:
     needs: [get-langs, filter]
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         lang: ${{ fromJson(needs.filter.outputs.changed_langs_json) }}
@@ -118,13 +120,13 @@ jobs:
     if: needs.filter.outputs.changed_langs_json != '[]'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -154,8 +156,10 @@ jobs:
           echo "Using layers: $LAYERS_STR"
           # Decide whether to push or load locally (manual runs can set push=false)
           DOCKER_OUTPUT_FLAG="--push"
+          ATTEST_ARGS=(--provenance=mode=max --sbom=true)
           if [ "${PUSH_IMAGES:-true}" = "false" ]; then
             DOCKER_OUTPUT_FLAG="--load"
+            ATTEST_ARGS=()
           fi
           # Determine channel tag based on branch
           BRANCH="${{ github.ref_name }}"
@@ -169,6 +173,7 @@ jobs:
             --cache-from type=gha,scope=rasa-build \
             --cache-to type=gha,scope=rasa-build,mode=max \
             --platform linux/amd64 \
+            "${ATTEST_ARGS[@]}" \
             -t ghcr.io/$REPO_NAME_LC:${CHANNEL_TAG} \
             -t ghcr.io/$REPO_NAME_LC:${SAFE_TAG}-${BRANCH}-${{ github.sha }} \
             $DOCKER_OUTPUT_FLAG .

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,101 @@
+name: Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - dev
+  schedule:
+    - cron: "19 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  trivy:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          exit-code: "1"
+
+  python-dependencies:
+    name: Python Dependency Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Install pip-audit
+        run: python -m pip install --upgrade pip pip-audit
+
+      - name: Audit Python dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_output="$(mktemp)"
+          audit_status=0
+
+          python -m pip_audit -r requirements.txt --format=json --aliases=off --desc=off --output "$audit_output" || audit_status=$?
+
+          if [[ ! -s "$audit_output" ]]; then
+          echo "pip-audit did not produce JSON output" >&2
+          exit "${audit_status:-1}"
+          fi
+
+          python - "$audit_output" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text())
+          actionable = []
+
+          for dependency in payload.get("dependencies", []):
+            name = dependency.get("name", "<unknown>")
+            version = dependency.get("version", "<unknown>")
+            for vulnerability in dependency.get("vulns", []):
+              fix_versions = vulnerability.get("fix_versions") or []
+              if fix_versions:
+                actionable.append(
+                  {
+                    "name": name,
+                    "version": version,
+                    "id": vulnerability.get("id", "<unknown>"),
+                    "fix_versions": fix_versions,
+                  }
+                )
+
+          if not actionable:
+            print("No Python vulnerabilities with known fixes found.")
+            sys.exit(0)
+
+          print("Python vulnerabilities with known fixes:")
+          for vulnerability in actionable:
+            fixes = ", ".join(vulnerability["fix_versions"])
+            print(
+              f"- {vulnerability['name']} {vulnerability['version']}: "
+              f"{vulnerability['id']} -> {fixes}"
+            )
+
+          sys.exit(1)
+          PY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rasa/rasa:3.6.21
+FROM rasa/rasa:3.6.21@sha256:7c0204065d4859e1b7a691c972ca3d26f5d39ad23fbd992b654084721226d813
 
 ENV RASA_TELEMETRY_ENABLED=false
 ENV SQLALCHEMY_SILENCE_UBER_WARNING=1
@@ -44,6 +44,6 @@ EXPOSE 5005
 
 USER 1001
 
-# Always run with API, CORS, timeout settings, and core endpoints file
-ENTRYPOINT ["rasa", "run", "--enable-api", "--cors", "*", "--endpoints", "src/core/endpoints.yml", "--request-timeout", "3600", "--response-timeout", "7200"]
+# Always run with API, native token auth, bounded timeouts, and the core endpoints file.
+ENTRYPOINT ["sh", "-lc", "test -n \"${RASA_AUTH_TOKEN:-}\" || { echo 'RASA_AUTH_TOKEN is required' >&2; exit 1; }; exec rasa run --enable-api --auth-token \"$RASA_AUTH_TOKEN\" --endpoints src/core/endpoints.yml --request-timeout 300 --response-timeout 300"]
 CMD []

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ TRACKER_STORE_URL=redis
 TRACKER_STORE_DB=0
 LOCK_STORE_URL=redis
 LOCK_STORE_DB=1
+RASA_AUTH_TOKEN=<shared-rasa-token>
 DUCKLING_ENDPOINT_URL=http://duckling:8000
 RASA_SHELL_STREAM_READING_TIMEOUT_IN_SECONDS=3600
 ```
@@ -75,13 +76,13 @@ bash scripts/layer_rasa_lang.sh --dry-run=stdout en/US
 Run API:
 
 ```bash
-rasa run --enable-api --cors '*' --model models --endpoints src/core/endpoints.yml --request-timeout 3600 --response-timeout 7200
+rasa run --enable-api --auth-token "$RASA_AUTH_TOKEN" --model models --endpoints src/core/endpoints.yml --request-timeout 300 --response-timeout 300
 ```
 
 Run interactive shell:
 
 ```bash
-rasa shell --model models --endpoints src/core/endpoints.yml --request-timeout 3600 --response-timeout 7200
+rasa shell --model models --endpoints src/core/endpoints.yml --request-timeout 300 --response-timeout 300
 ```
 
 ### VS Code tasks (optional)
@@ -120,9 +121,12 @@ TRACKER_STORE_URL=<redis-host>
 TRACKER_STORE_DB=<unique-int>
 LOCK_STORE_URL=<redis-host>
 LOCK_STORE_DB=<unique-int>
+RASA_AUTH_TOKEN=<shared-rasa-token>
 ```
 
 For multi-language deployment, run one container per locale image and assign unique Redis tracker/lock DB pairs.
+Keep Rasa on a private service network behind the Webapp; the published image
+ships with CORS disabled for browser clients.
 
 ### Minimal production compose snippet (single locale)
 
@@ -131,14 +135,13 @@ services:
   rasa-en:
     image: ghcr.io/09c7b0ed-f907-45d2-bc7c-48b17f2d9940/rasa:en-US-latest
     depends_on: [action, redis, duckling]
-    ports:
-      - "5005:5005"
     environment:
       ACTION_ENDPOINT_URL: http://action:5055/webhook
       TRACKER_STORE_URL: redis
       TRACKER_STORE_DB: 0
       LOCK_STORE_URL: redis
       LOCK_STORE_DB: 1
+      RASA_AUTH_TOKEN: "<shared-rasa-token>"
 
   action:
     image: ghcr.io/09c7b0ed-f907-45d2-bc7c-48b17f2d9940/action:latest
@@ -153,14 +156,15 @@ services:
 Production image runtime command:
 
 ```bash
-rasa run --enable-api --endpoints src/core/endpoints.yml
+rasa run --enable-api --auth-token "$RASA_AUTH_TOKEN" --endpoints src/core/endpoints.yml --request-timeout 300 --response-timeout 300
 ```
 
 ---
 
 ## 3) Quick verification
 
-- Check health endpoint: `curl -s http://localhost:5005/status`
+- Check auth enforcement: `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5005/status` should return `401`
+- Check authenticated health endpoint: `curl -s "http://localhost:5005/status?token=<shared-rasa-token>"`
 - Verify Action is reachable from each Rasa container
 - Verify Redis DB allocation does not overlap across locales
 - Send a test message through REST webhook and confirm Action callbacks
@@ -184,7 +188,7 @@ bash scripts/layer_rasa_lang.sh --dry-run=stdout <lang>/<REGION>
 Run API with latest local model:
 
 ```bash
-rasa run --enable-api --cors '*' --model models --endpoints src/core/endpoints.yml
+rasa run --enable-api --auth-token "$RASA_AUTH_TOKEN" --model models --endpoints src/core/endpoints.yml --request-timeout 300 --response-timeout 300
 ```
 
 Run local interactive shell:

--- a/src/core/endpoints.yml
+++ b/src/core/endpoints.yml
@@ -10,6 +10,5 @@ tracker_store:
   url: ${TRACKER_STORE_URL}
   db: ${TRACKER_STORE_DB}
 cors:
-  enabled: true
-  allowed_origins:
-    - "*"
+  enabled: false
+  allowed_origins: []


### PR DESCRIPTION
## Summary

This PR hardens the published Rasa runtime and the repository's image/security automation.

## What changed

- pin the published Rasa base image by digest
- remove wildcard CORS from the published runtime
- reduce request and response timeouts to bounded defaults
- require `RASA_AUTH_TOKEN` for API startup and run Rasa with native token auth
- update runtime and compose documentation to reflect the new auth requirement
- pin GitHub Actions by commit SHA in the image publish workflow
- enable buildx attestations with SBOM and provenance
- add Dependabot for Docker, pip, and GitHub Actions
- add blocking security scans:
  - Trivy for `HIGH` and `CRITICAL`
  - `pip-audit` gating only on vulnerabilities with known fixes

## Validation

- rebuilt the published Rasa image successfully using the workflow-style `LAYERS` build arg
- verified live auth behavior against the built image:
  - unauthenticated `/status` returns `401`
  - authenticated `/status?token=...` returns `200`
- verified editor checks on touched files
- verified clean git diff hygiene