### PR TITLE
Add new examples

### DIFF
--- a/src/locales/en/US/data/nlu/intent/visualization.yml
+++ b/src/locales/en/US/data/nlu/intent/visualization.yml
@@ -87,6 +87,12 @@ nlu:
       - Give me [DTN](metric) performance [by quarter](group_by) over [the last 12 months](date)
       - Display data from [Q1 2023]{"entity": "date", "role": "lower"} to [Q2 2023]{"entity": "date", "role": "upper"} vs [Q3 2023]{"entity": "date", "role": "lower"} to [Q4 2023]{"entity": "date", "role": "upper"}
       - Compare patients aged [30]{"entity": "age", "role": "lower"} to [45]{"entity": "age", "role": "upper"} with those aged [60]{"entity": "age", "role": "lower"} to [80]{"entity": "age", "role": "upper"}
+      - Show me [DTN](metric) in [2025](date)
+      - Chart [DTN](metric) for [2024](date)
+      - Display [DTN](metric) from [2025](date)
+      - Give me [DIDO](metric) data for [2023](date)
+      - Show [DTN](metric) during [2025](date)
+
   - intent: update_visualization
     examples: |
       - Change the chart to a [bar](chart_type) graph
@@ -121,6 +127,25 @@ nlu:
       - show only patients [from 2023]{"entity": "date"}
       - filter to [2024]{"entity": "date"} only
       - only data from [2025]{"entity": "date"}
+      - filter for patients below [50]{"entity": "age", "role": "upper"}
+      - filter for age under [65]{"entity": "age", "role": "upper"}
+      - only show patients younger than [40]{"entity": "age", "role": "upper"}
+      - show patients below the age of [30]{"entity": "age", "role": "upper"}
+      - restrict to patients under [55]{"entity": "age", "role": "upper"}
+      - filter for [ischemic](stroke_type) strokes
+      - filter for [transient ischemic](stroke_type) strokes
+      - show only [intracerebral hemorrhage](stroke_type) patients
+      - Include only patients from [2025](date)
+      - Show data from [2025](date) only
+      - Filter for [2024](date) patients
+      - Only show [2025](date) records
+      - show data from [2024](date) and [2025](date)
+      - show data from [2023](date) to [2025](date)
+      - show [2024](date) and [2025](date) data
+      - display data for [2023](date) and [2024](date)
+      - show data from [2024](date) and [2025](date)
+      - include [2024](date) and [2025](date)
+      - show data for [2024](date) and [2025](date)
 
   - intent: clarify_visualization
     examples: |


### PR DESCRIPTION
This pull request expands the natural language understanding (NLU) training data for visualization intents, making the system better at recognizing user requests involving specific years, age filters, and stroke types. The changes add more varied phrasings to improve the model's ability to interpret user queries related to data visualization.

**Enhancements to NLU training data:**

*Visualization intent improvements:*
- Added new example phrases for the `visualization` intent that reference specific years (2023, 2024, 2025) and metrics (e.g., "Show me DTN in 2025", "Give me DIDO data for 2023") to improve recognition of date-based and metric-based queries.

*Filtering and data selection intent improvements:*
- Expanded the `filter_visualization` intent with additional examples for filtering by age (e.g., "filter for patients below 50", "only show patients younger than 40") and by stroke type (e.g., "filter for ischemic strokes", "show only intracerebral hemorrhage patients").
- Added more diverse date-based filtering examples, including requests for data from multiple years or year ranges (e.g., "show data from 2023 to 2025", "include 2024 and 2025").